### PR TITLE
:octocat: Set NDG2 as default option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: modparams
 Title: Set up and modify NHP model parameter lists
-Version: 0.4.2
+Version: 0.5.0
 Authors@R:
     person(
         "Fran", "Barton",

--- a/R/write_params_json.R
+++ b/R/write_params_json.R
@@ -1,7 +1,7 @@
 #' Create custom NHP model parameters and write them to a JSON file
 #'
 #' @inheritParams create_custom_params
-#' @param save_to path. The directory to which the .json file will be written.
+#' @param save_dir path. The directory to which the .json file will be written.
 #'  The default value is `"."` (the user's current working directory).
 #'
 #' @returns The full file path to which the .json file has been written
@@ -15,7 +15,7 @@ write_params_json <- function(
 ) {
   params_lst <- create_custom_params(config_file, intervals_data, ...)
   filenm_stub <- glue::glue_data(params_lst, "{scenario}_{create_datetime}")
-  write_params_to_file(params_lst, filenm_stub, save_to)
+  write_params_to_file(params_lst, filenm_stub, save_dir)
 }
 
 
@@ -93,8 +93,8 @@ get_local_sysfile <- function(...) {
 #' @inheritParams write_params_json
 #' @returns The full file path to which the .json file has been written
 #' @export
-write_params_to_file <- function(params_lst, filenm_stub, save_to) {
-  file_out <- file.path(save_to, paste0(filenm_stub, ".json"))
+write_params_to_file <- function(params_lst, filenm_stub, save_dir) {
+  file_out <- file.path(save_dir, paste0(filenm_stub, ".json"))
   yyj_write_opts <- yyjsonr::opts_write_json(pretty = TRUE, auto_unbox = TRUE)
   yyjsonr::write_json_file(params_lst, file_out, yyj_write_opts)
   file_out

--- a/R/write_params_json.R
+++ b/R/write_params_json.R
@@ -54,24 +54,21 @@ create_custom_params <- function(
   intervals <- get_intervals_list(intervals_data)
   time_profiles <- get_linear_time_profiles(intervals_data)
 
-  params_lst <- yaml12::read_yaml(config_file) |>
+  if (ndg_variant == "ndg2") {
+    ndg_values <- yaml12::read_yaml(get_local_sysfile("ndg2_values.yaml"))
+  } else {
+    ndg_values <- yaml12::read_yaml(get_local_sysfile("ndg3_values.yaml"))
+  }
+  yaml12::read_yaml(config_file) |>
     purrr::assign_in("create_datetime", create_dttm) |>
+    purrr::assign_in("non-demographic_adjustment", ndg_values) |>
     purrr::modify_at("time_profile_mappings", \(x) {
       purrr::list_modify(x, !!!time_profiles)
     }) |>
     purrr::list_modify(!!!intervals) |>
     purrr::list_modify(...)
-
-  if (params_lst[["non-demographic_adjustment"]] == "ndg3") {
-    ndg3_values <- yaml12::read_yaml(get_local_sysfile("ndg3_values.yaml"))
-    purrr::assign_in(params_lst, "non-demographic_adjustment", ndg3_values)
-  } else if (params_lst[["non-demographic_adjustment"]] == "ndg2") {
-    ndg2_values <- yaml12::read_yaml(get_local_sysfile("ndg2_values.yaml"))
-    purrr::assign_in(params_lst, "non-demographic_adjustment", ndg2_values)
-  } else {
-    params_lst
-  }
 }
+
 
 #' Helper function to return the file path to a bundled base config YAML file
 #'

--- a/R/write_params_json.R
+++ b/R/write_params_json.R
@@ -6,7 +6,13 @@
 #'
 #' @returns The full file path to which the .json file has been written
 #' @export
-write_params_json <- function(config_file, intervals_data, save_to = ".", ...) {
+write_params_json <- function(
+  config_file,
+  intervals_data,
+  ndg_variant = c("ndg2", "ndg3"),
+  save_dir = ".",
+  ...
+) {
   params_lst <- create_custom_params(config_file, intervals_data, ...)
   filenm_stub <- glue::glue_data(params_lst, "{scenario}_{create_datetime}")
   write_params_to_file(params_lst, filenm_stub, save_to)
@@ -24,6 +30,8 @@ write_params_json <- function(config_file, intervals_data, save_to = ".", ...) {
 #'  Must contain columns `type`, `change_factor`, `strategy` and `interval`.
 #'  These intervals will be used to create the params and time profile mappings
 #'  for all included TPMAs (aka "strategies").
+#' @param ndg_variant string. The set of non-demographic growth adjustment
+#'  values to use. Possible values are "ndg2" or "ndg3", with ndg2 the default.
 #' @param ... Named arguments that you can use to provide values that are empty
 #'  in the config file, and to potentially overwrite default values.
 #'  Using `...` is an alternative to editing the config file directly, and may
@@ -35,7 +43,13 @@ write_params_json <- function(config_file, intervals_data, save_to = ".", ...) {
 #'
 #' @returns A list of custom params
 #' @export
-create_custom_params <- function(config_file, intervals_data, ...) {
+create_custom_params <- function(
+  config_file,
+  intervals_data,
+  ndg_variant = c("ndg2", "ndg3"),
+  ...
+) {
+  ndg_variant <- rlang::arg_match(ndg_variant)
   create_dttm <- substr(sub(" ", "_", gsub("[:-]", "", Sys.time())), 1L, 15L)
   intervals <- get_intervals_list(intervals_data)
   time_profiles <- get_linear_time_profiles(intervals_data)

--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ happen and what you actually observed.
 
 Currently (April 2026) we are at v4.4 of the NHP model:
 
-* The package currently only handles NDG3 values.
 * Only "linear" time profiles are catered for, which matches the current design
   of the NHP model.
 * The v4.4 YAML config file included in the package is likely to be suitable for

--- a/inst/config_v4.4.yaml
+++ b/inst/config_v4.4.yaml
@@ -31,7 +31,7 @@ baseline_adjustment:
 waiting_list_adjustment:
   ip: {}
   op: {}
-non-demographic_adjustment: ndg3
+non-demographic_adjustment:
 activity_avoidance:
   ip: {}
   op: {}

--- a/man/create_custom_params.Rd
+++ b/man/create_custom_params.Rd
@@ -4,7 +4,12 @@
 \alias{create_custom_params}
 \title{Create a list of custom NHP model parameters}
 \usage{
-create_custom_params(config_file, intervals_data, ...)
+create_custom_params(
+  config_file,
+  intervals_data,
+  ndg_variant = c("ndg2", "ndg3"),
+  ...
+)
 }
 \arguments{
 \item{config_file}{string. File path to a YAML config file that specifies
@@ -14,6 +19,9 @@ essential elements of the params list to be created.}
 Must contain columns \code{type}, \code{change_factor}, \code{strategy} and \code{interval}.
 These intervals will be used to create the params and time profile mappings
 for all included TPMAs (aka "strategies").}
+
+\item{ndg_variant}{string. The set of non-demographic growth adjustment
+values to use. Possible values are "ndg2" or "ndg3", with ndg2 the default.}
 
 \item{...}{Named arguments that you can use to provide values that are empty
 in the config file, and to potentially overwrite default values.

--- a/man/write_params_json.Rd
+++ b/man/write_params_json.Rd
@@ -4,7 +4,13 @@
 \alias{write_params_json}
 \title{Create custom NHP model parameters and write them to a JSON file}
 \usage{
-write_params_json(config_file, intervals_data, save_to = ".", ...)
+write_params_json(
+  config_file,
+  intervals_data,
+  ndg_variant = c("ndg2", "ndg3"),
+  save_dir = ".",
+  ...
+)
 }
 \arguments{
 \item{config_file}{string. File path to a YAML config file that specifies
@@ -15,7 +21,10 @@ Must contain columns \code{type}, \code{change_factor}, \code{strategy} and \cod
 These intervals will be used to create the params and time profile mappings
 for all included TPMAs (aka "strategies").}
 
-\item{save_to}{path. The directory to which the .json file will be written.
+\item{ndg_variant}{string. The set of non-demographic growth adjustment
+values to use. Possible values are "ndg2" or "ndg3", with ndg2 the default.}
+
+\item{save_dir}{path. The directory to which the .json file will be written.
 The default value is \code{"."} (the user's current working directory).}
 
 \item{...}{Named arguments that you can use to provide values that are empty

--- a/man/write_params_to_file.Rd
+++ b/man/write_params_to_file.Rd
@@ -4,14 +4,14 @@
 \alias{write_params_to_file}
 \title{Write a list of params to a .json file}
 \usage{
-write_params_to_file(params_lst, filenm_stub, save_to)
+write_params_to_file(params_lst, filenm_stub, save_dir)
 }
 \arguments{
 \item{params_lst}{R list of custom params (created by \link{create_custom_params})}
 
 \item{filenm_stub}{A file name stub (.json extension will be added)}
 
-\item{save_to}{path. The directory to which the .json file will be written.
+\item{save_dir}{path. The directory to which the .json file will be written.
 The default value is \code{"."} (the user's current working directory).}
 }
 \value{


### PR DESCRIPTION
Closes #16

This PR:

* Moves NDG choice from the YAML config file to a function argument (`ndg_variant`). Passing in an ndg value to override the config default previously would have involved passing in an argument named `non-demographic_adjustment` via `...`, which is an awkward argument to type due to the `-` requiring backticks, and is hard to remember
* Bumps the package version to 0.5