### PR TITLE
Passes through ndg variable to where it can actually work

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: modparams
 Title: Set up and modify NHP model parameter lists
-Version: 0.5.0
+Version: 0.5.1
 Authors@R:
     person(
         "Fran", "Barton",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,6 @@ Description: Set up and modify NHP model parameter lists, and export them as
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 Depends: R (>= 4.4)
 Imports:
     dplyr,
@@ -29,3 +28,4 @@ Imports:
 Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
+Config/roxygen2/version: 8.0.0

--- a/R/write_params_json.R
+++ b/R/write_params_json.R
@@ -7,13 +7,13 @@
 #' @returns The full file path to which the .json file has been written
 #' @export
 write_params_json <- function(
-  config_file,
+  config,
   intervals_data,
   ndg_variant = c("ndg2", "ndg3"),
   save_dir = ".",
   ...
 ) {
-  params_lst <- create_custom_params(config_file, intervals_data, ...)
+  params_lst <- create_custom_params(config, intervals_data, ndg_variant, ...)
   filenm_stub <- glue::glue_data(params_lst, "{scenario}_{create_datetime}")
   write_params_to_file(params_lst, filenm_stub, save_dir)
 }
@@ -24,7 +24,7 @@ write_params_json <- function(
 #' Use a YAML config file to set up a base params list. Intervals data must also
 #'  be supplied. Specific values may be supplied using named values in `...`.#'  These will replace existing values or NULLs from the base config.
 #'
-#' @param config_file string. File path to a YAML config file that specifies
+#' @param config string. File path to a YAML config file that specifies
 #'  essential elements of the params list to be created.
 #' @param intervals_data data frame containing p10 and p90 intervals for TPMAs.
 #'  Must contain columns `type`, `change_factor`, `strategy` and `interval`.
@@ -44,7 +44,7 @@ write_params_json <- function(
 #' @returns A list of custom params
 #' @export
 create_custom_params <- function(
-  config_file,
+  config,
   intervals_data,
   ndg_variant = c("ndg2", "ndg3"),
   ...
@@ -59,7 +59,7 @@ create_custom_params <- function(
   } else {
     ndg_values <- yaml12::read_yaml(get_local_sysfile("ndg3_values.yaml"))
   }
-  yaml12::read_yaml(config_file) |>
+  yaml12::read_yaml(config) |>
     purrr::assign_in("create_datetime", create_dttm) |>
     purrr::assign_in("non-demographic_adjustment", ndg_values) |>
     purrr::modify_at("time_profile_mappings", \(x) {

--- a/man/create_custom_params.Rd
+++ b/man/create_custom_params.Rd
@@ -5,14 +5,14 @@
 \title{Create a list of custom NHP model parameters}
 \usage{
 create_custom_params(
-  config_file,
+  config,
   intervals_data,
   ndg_variant = c("ndg2", "ndg3"),
   ...
 )
 }
 \arguments{
-\item{config_file}{string. File path to a YAML config file that specifies
+\item{config}{string. File path to a YAML config file that specifies
 essential elements of the params list to be created.}
 
 \item{intervals_data}{data frame containing p10 and p90 intervals for TPMAs.

--- a/man/write_params_json.Rd
+++ b/man/write_params_json.Rd
@@ -5,7 +5,7 @@
 \title{Create custom NHP model parameters and write them to a JSON file}
 \usage{
 write_params_json(
-  config_file,
+  config,
   intervals_data,
   ndg_variant = c("ndg2", "ndg3"),
   save_dir = ".",
@@ -13,7 +13,7 @@ write_params_json(
 )
 }
 \arguments{
-\item{config_file}{string. File path to a YAML config file that specifies
+\item{config}{string. File path to a YAML config file that specifies
 essential elements of the params list to be created.}
 
 \item{intervals_data}{data frame containing p10 and p90 intervals for TPMAs.


### PR DESCRIPTION
Closes #19.
The `ndg_variant` variable previously wasn't being passed through to the internal function (because originally I just thought users could use `non-demographic_adjustment` via `...` - but when I introduced the more user-friendly `ndg_variant` argument I forgot that this wouldn't get picked up by `...`!)